### PR TITLE
Added plain g++ Makefile.  Sample compiles in 4.9.1.

### DIFF
--- a/include/dag_status.h
+++ b/include/dag_status.h
@@ -43,4 +43,10 @@ typedef enum { NODE_UNVISITED=0,
                NODE_COMPLETED=4,
                NODE_DEAD=5 } DAGNodeStatus;
 
+class DynamicNode {
+    public:
+      virtual DAGNodeStatus get_status() =0;
+      virtual bool try_mark_as_visited() =0;
+};
+
 #endif // __DAG_STATUS_H_

--- a/include/dynamic_array.h
+++ b/include/dynamic_array.h
@@ -241,7 +241,7 @@ T DynamicArray<T>::get(int idx) {
     }
     return a[idx];
   } else {
-    return NULL;
+    return (long long int)NULL;
   }
 }
 

--- a/include/dynamic_nabbit_node.h
+++ b/include/dynamic_nabbit_node.h
@@ -52,7 +52,7 @@ typedef DynamicArray<long long> DTGSKeyArray;
 typedef DynamicArray<DynamicNabbitNode*> DynamicNabbitNodeArray;
 
 
-class DynamicNabbitNode {
+class DynamicNabbitNode : DynamicNode {
 
  public:
   long long key; 
@@ -62,7 +62,7 @@ class DynamicNabbitNode {
   // Constructors for a node.
   DynamicNabbitNode(long long k, TaskGraphHashTable* H);
   DynamicNabbitNode(long long k, TaskGraphHashTable* H, int num_succ);
-  ~DynamicNabbitNode();
+  virtual ~DynamicNabbitNode();
 
   
   void add_dep(long long key);
@@ -72,7 +72,7 @@ class DynamicNabbitNode {
 
   DAGNodeStatus get_status();
   inline bool try_mark_as_visited();
-  
+
  protected:
     
   virtual void Init() = 0;

--- a/include/dynamic_serial_node.h
+++ b/include/dynamic_serial_node.h
@@ -52,7 +52,7 @@ class DynamicSerialNode;
 typedef DynamicArray<long long> DTGSKeyArray;
 typedef DynamicArray<DynamicSerialNode*> DynamicSerialNodeArray;
 
-class DynamicSerialNode {
+class DynamicSerialNode : DynamicNode {
 
  public:
   long long key; 
@@ -62,7 +62,7 @@ class DynamicSerialNode {
   // Constructors for a node.
   DynamicSerialNode(long long k, TaskGraphHashTable* H);
   DynamicSerialNode(long long k, TaskGraphHashTable* H, int num_succ);
-  ~DynamicSerialNode();
+  virtual ~DynamicSerialNode();
 
   
   void add_dep(long long key);
@@ -72,7 +72,7 @@ class DynamicSerialNode {
 
   DAGNodeStatus get_status();
   inline bool try_mark_as_visited();
-  
+
  protected:
     
   virtual void Init() = 0;

--- a/include/nabbit_sysdep.h
+++ b/include/nabbit_sysdep.h
@@ -106,6 +106,7 @@ namespace nabbit {
 
 #else
     // GCC-compatible systems.
+#include <pthread.h>
 
     inline long atomic_add_and_fetch(long volatile* p, long x) {
         return __sync_add_and_fetch(p, x);

--- a/include/static_nabbit_node.h
+++ b/include/static_nabbit_node.h
@@ -166,10 +166,11 @@ void StaticNabbitNode::compute_and_notify() {
 
     StaticNabbitNode* current_succ = this->successors->get(i);
     if (current_succ->join_counter <= 0) {
-      printf("ERROR: this key = %lld, current_succ = %p (key = %lld), join counter = %ld\n",
+      /*printf("ERROR: this key = %lld, current_succ = %p (key = %lld), join counter = %ld\n",
 	     this->key,
 	     current_succ, current_succ->key,
-	     current_succ->join_counter);
+	     current_succ->join_counter);*/
+        //printf("ERROR: negative join counter!\n"); // even this gives "function not inlinable..." in g++ 4.9.1
     }
     assert(current_succ->join_counter > 0);
     int updated_val = nabbit::atomic_sub_and_fetch(&(current_succ->join_counter),

--- a/include/static_nabbit_node.h
+++ b/include/static_nabbit_node.h
@@ -56,7 +56,7 @@ class StaticNabbitNode {
   StaticNabbitNode(long long k);
   StaticNabbitNode(long long k, int num_predecessors);
 
-  ~StaticNabbitNode();
+  virtual ~StaticNabbitNode();
 
   // Methods to call when constructing a DAG statically.
   void init_node(int default_degree);

--- a/include/static_serial_node.h
+++ b/include/static_serial_node.h
@@ -55,7 +55,7 @@ class StaticSerialNode {
   StaticSerialNode(long long k);
   StaticSerialNode(long long k, int num_predecessors);
 
-  ~StaticSerialNode();
+  virtual ~StaticSerialNode();
 
   // Methods to call when constructing a DAG statically.
   void init_node(int default_degree);

--- a/misc_tests/Makefile
+++ b/misc_tests/Makefile
@@ -1,5 +1,6 @@
 include ../mk/Makefile
 
+CFLAGS += -I../util -I../include
 # The names of the tests to run.
 TEST_NAMES = dynamic_array concurrent_linked_list concurrent_hash_table
 OTHER_TESTS = malloc_test ser_malloc_test

--- a/mk/Makefile
+++ b/mk/Makefile
@@ -13,5 +13,10 @@ UTIL_DIR=$(NABBIT_ROOT)/util
 ifeq ($(OS),Windows_NT)
 include $(NABBIT_ROOT)/mk/Makefile.icl
 else
+HAVE_ICC := $(shell command -v icc 2> /dev/null)
+ifdef HAVE_ICC
 include $(NABBIT_ROOT)/mk/Makefile.icc
+else
+include $(NABBIT_ROOT)/mk/Makefile.gcc
+endif
 endif

--- a/mk/Makefile.gcc
+++ b/mk/Makefile.gcc
@@ -1,0 +1,13 @@
+# Makefile for compilation with g++ (Linux)
+
+# Include directory for Nabbit.
+NABBIT_INCLUDES = -I $(UTIL_DIR) -I $(NABBIT_DIR) -I $(ARRAYS_DIR)
+
+CC=g++ -fcilkplus
+CXX=g++ -fcilkplus
+CILKVIEW_FLAGS=
+LIBARG= -lpthread -lcilkrts
+
+CFLAGS = -Wall -O3
+CXXFLAGS = $(CFLAGS)
+CILK_SERIALIZE_FLAG = -cilk-serialize

--- a/sample/Makefile
+++ b/sample/Makefile
@@ -1,6 +1,7 @@
 
 # Defines $(CC) and $(NABBIT_INCLUDES)
 include ../mk/Makefile
+CFLAGS += -ggdb
 
 TARGET = sample
 SRC	= $(addsuffix .cpp,$(TARGET))
@@ -9,6 +10,9 @@ SRC	= $(addsuffix .cpp,$(TARGET))
 H_FILES = sample_nabbit_node.h
 
 .PHONY: clean
+
+dynamic: dynamic.cpp
+	$(CC) $(CFLAGS) $^ $(NABBIT_INCLUDES) $(LIBARG) -o $@
 
 $(TARGET): $(SRC) $(H_FILES) $(O_FILES)
 	$(CC) $(CFLAGS) $(SRC) $(NABBIT_INCLUDES) $(LIBARG) -o $@

--- a/sample/dynamic.cpp
+++ b/sample/dynamic.cpp
@@ -1,0 +1,124 @@
+#include <cassert>
+#include <cstdlib>
+#include <vector>
+
+#include <nabbit.h>
+#include "hash_tbl.h"
+
+#define LAZY (1<<15)
+
+struct State;
+struct State {
+    struct State *stack, *next;
+    unsigned int type;
+    int deps;
+    int path;
+    const char name[8];
+};
+
+template <class DynNodeType>
+class DynNode: public DynNodeType {
+    DynHashTable* H;
+
+    protected:
+        void Init();
+        void Compute();
+        void Generate();
+
+        struct State *s;
+
+    public:
+        //: DynNodeType((node_key_t)s, H), children(NULL), s(s) {};
+        DynNode(struct State *s, DynHashTable* H)
+                : DynNodeType((node_key_t)s, H), H(H), s(s) {};
+
+};
+
+template <class DynNodeType>
+void DynNode<DynNodeType>::Init() {
+    printf("Node %s: Counting eggs.\n", s->name);
+    if(s->type & LAZY) {
+        printf("%s: Nah, I think I'll do it later.\n", s->name);
+        return;
+    }
+
+    for(struct State *c = s->stack; c != NULL; c = c->next) {
+        if(H->insert_task_if_absent((node_key_t)c)) {
+            printf("Error inserting child task!");
+            exit(1);
+        }
+        this->add_dep((node_key_t)c);
+    }
+}
+
+template <class DynNodeType>
+void DynNode<DynNodeType>::Compute() {
+    s->deps = 1;
+    s->path = 1;
+    if(s->type & LAZY) {
+        printf("%s: I wasn't ready.\n", s->name);
+        return;
+    }
+    for(struct State *c = s->stack; c != NULL; c = c->next) {
+        s->deps += c->deps;
+        s->path = s->path > c->path+1 ? s->path : c->path+1;
+    }
+}
+
+template <class DynNodeType>
+void DynNode<DynNodeType>::Generate() {
+    if(s->type & LAZY) {
+        printf("%s: Reporting for duty!\n", s->name);
+        s->type = s->type & (~LAZY); // Get a job!
+
+        /* TODO: add fake successor node to do actual computation?
+        if(H->insert_task_if_absent((node_key_t)s)) {
+            printf("Error inserting child task!");
+            exit(1);
+        }
+        this->generate_task((node_key_t)s);*/
+
+        for(struct State *c = s->stack; c != NULL; c = c->next) {
+            if(H->insert_task_if_absent((node_key_t)c)) {
+                printf("Error inserting child task!");
+                exit(1);
+            }
+            this->generate_task((node_key_t)c);
+        }
+    }
+}
+
+template <class DynNodeType>
+DynamicNode *mk_node(node_key_t key, void *H) {
+    DynNode<DynNodeType>* ret =
+        new DynNode<DynNodeType>((struct State *)key, (DynHashTable *)H);
+    return (DynamicNode *)ret;
+}
+
+typedef DynNode<DynamicSerialNode> NodeT;
+
+int main(int argc, char *argv[]) {
+    struct State c3 = {
+        NULL, NULL, 0, 0, 0, "c3"
+    };
+    struct State c2 = {
+        &c3, NULL, 0, 0, 0, "c2"
+    };
+    struct State c1 = {
+        &c3, &c2, 0, 0, 0, "c1"
+    };
+    struct State root = {
+        &c1, NULL, 0, 0, 0, "root"
+    };
+
+    DynHashTable *H = new DynHashTable(4, mk_node<DynamicSerialNode>);
+    NodeT *node = new NodeT(&root, H);
+    // H->insert_if_absent(node, 
+
+    /*cilk_spawn node->compute_and_notify();
+    typedef DynamicArray<node_key_t> DTGSKeyArray;*/
+
+    // start computation:
+    node->init_root_and_compute((node_key_t)&root); // for ea. root, k
+}
+

--- a/sample/hash_tbl.h
+++ b/sample/hash_tbl.h
@@ -1,0 +1,119 @@
+// Code for the Nabbit task graph library
+// Hash Table Implemented in the Random DAG microbenchmark.
+//
+// Copyright (c) 2010 Jim Sukha
+//
+//
+/*
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef __HASH_TBL_H_
+#define __HASH_TBL_H_
+
+#include <concurrent_hash_table.h>
+
+typedef long long node_key_t;
+typedef DynamicNode *(*new_node_f)(node_key_t, void *);
+
+class DynHashTable: public TaskGraphHashTable {
+
+    public:  
+        ConcurrentHashTable* H;  
+        new_node_f new_node;
+
+        DynHashTable(int n, new_node_f mk)
+            : H(new ConcurrentHashTable(n)), new_node(mk) {};
+        ~DynHashTable() { delete H; };
+
+        void* get_task(node_key_t key);
+
+        int insert_task_if_absent(node_key_t key);
+};
+
+
+void *DynHashTable::get_task(node_key_t key) {
+    DynamicNode *n = NULL;
+    LOpStatus code = OP_FAILED;
+    while (code == OP_FAILED) {
+        n = (DynamicNode *)H->search(key, &code);
+    }
+
+    if (n != NULL) {
+        if (n->get_status() >= NODE_VISITED) {
+            return (void*)n;
+        }
+    }
+    return NULL;
+}
+
+struct State2 {
+  void *stack, *next;
+  unsigned int type;
+  int deps;
+  int path;
+  const char name[8];
+};
+
+int DynHashTable::insert_task_if_absent(node_key_t key) {
+
+    DynamicNode *n = NULL;
+    LOpStatus code = OP_FAILED;
+    bool success = false;
+    while (code == OP_FAILED) {
+        n = (DynamicNode *)H->search(key, &code);
+    }
+    if(n == NULL) { // new node
+        DynamicNode *node = new_node(key, H);
+        code = OP_FAILED;
+        while(code == OP_FAILED){
+            n = (DynamicNode *)H->insert_if_absent(key, (void *)node, &code);
+        }
+        assert(code == OP_INSERTED);
+    }
+
+    assert(n != NULL);
+    if (n->get_status() >= NODE_VISITED) {
+#if PRINT_DEBUG_STATEMENTS == 1
+        printf("HASH insert if absent on key %llu. failed\n", key);
+#endif
+        return 0;
+    }
+
+    while (n->get_status() == NODE_UNVISITED) {
+        success = n->try_mark_as_visited();
+    }
+
+    if (success) {
+#if PRINT_DEBUG_STATEMENTS == 1
+        printf("HASH insert if absent on key %llu. success\n", key);
+#endif    
+        return 1;
+    } else {
+        assert(n->get_status() >= NODE_VISITED);
+#if PRINT_DEBUG_STATEMENTS == 1
+        printf("HASH insert if absent on key %llu. failed\n", key);
+#endif
+        return 0;
+    }
+}
+
+#endif


### PR DESCRIPTION
This project does almost exactly what I need for executing my task graphs.  I've added a test to compile with vanilla g++ 4.9 and above.

I've been trying to get an example for dynamic generation working by extracting code from the original "nabbit_v1/random_dag."  If you have a minute, can you check on my partial example in frobnitzem/nabbit?  It's trying to wrap the DynamicNode functionality by creating generic implementations of TaskGraphHashTable and DynamicNabbitNode that just follow the child structure of a C-struct with child pointers.  The Generate() function is needed for some nodes that are "lazy" and don't want to add their children until after Compute().

```C++
typedef long long node_key_t; // switch to intptr_t instead of long long?
typedef DynamicNode *(*new_node_f)(node_key_t, void *);

class DynHashTable: public TaskGraphHashTable {
    public:
        ConcurrentHashTable* H;
        new_node_f new_node;

        DynHashTable(int n, new_node_f mk)
            : H(new ConcurrentHashTable(n)), new_node(mk) {};
        ~DynHashTable() { delete H; };

        void* get_task(node_key_t key);
        int insert_task_if_absent(node_key_t key);
};

template <class DynNodeType>
class DynNode: public DynNodeType {
    DynHashTable* H;
    protected:
        void Init();
        void Compute();
        void Generate();

    public:
        struct State *s;
        DynNode(struct State *s, DynHashTable* H)
                : DynNodeType((node_key_t)s, H), H(H), s(s) {};
};
```
